### PR TITLE
Implement custom JavaScript, JSON, and CSV tests for SNAP web apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Xymon Tests
+
+This repo containes a Python script that implements custom Xymon tests for SNAP web apps. These include tests to check the validity of CSV and JSON output, as well as JavaScript tests that run in a headless web browser to check for the presence of elements in the DOM.
+
+# Setup
+
+Clone this repo into `/opt/xymon/server/ext`. Then, to integrate the custom test script into the Xymon configuration, add this to Xymon's `tasks.cfg` file:
+
+```
+[snap]
+    ENVFILE /opt/xymon/server/etc/xymonserver.cfg
+    NEEDS xymond
+    CMD /opt/xymon/server/ext/snap.py
+    LOGFILE $XYMONSERVERLOGS/snap.log
+    INTERVAL 20m
+```
+
+This will run the full suite of tests every 20 minutes.
+
+# Writing tests
+
+Tests are grouped together by the domain name of the server. For example:
+
+```
+"example.org": [
+    {
+        "column": ...,
+        "type": ...,
+        "url": ...,
+        "text": ...,
+        "javascript": ...,
+        "lat_range": ...,
+        "lon_range": ...,
+        "click": ...,
+        "delay": ...
+    },
+]
+```
+
+The dictionary keys for each test are described in the following table:
+
+| Key         | Required                        | Description                                                       |
+| ----------- | ------------------------------- | ----------------------------------------------------------------- |
+| column      | Yes                             | The column in which this test will appear on the Xymon dashboard. |
+| type        | Yes                             | The type of this test. Options are javascript, csv, or json       |
+| url         | Yes                             | The URL to test.                                                  |
+| text        | Yes                             | A brief description of the test to be display on Xymon's test details page. |
+| javascript  | Yes, if `type` is set to javascript | If this is a JavaScript test, the chunk of JavaScript code to run. The chunk of JavaScript needs to return a boolean value. |
+| lat_range   | No                              | If set, choose a random latitude between the range provided. This will replace `{lat}` in the `url` and `text` values.      |
+| lon_range   | No                              | If set, choose a random longitude between the range provided. This will replace `{lon}` in the `url` and `text` values. |
+| click       | No                              | Selector of a DOM element to click before running a JavaScript test. |
+| delay       | No                              | Override the default number of seconds to wait between loading the page and performing a JavaScript test. |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Clone this repo into `/opt/xymon/server/ext`. Then, to integrate the custom test
 
 This will run the full suite of tests every 20 minutes.
 
-# Writing tests
+# Tests
 
 Tests are grouped together by the domain name of the server. For example:
 
@@ -50,3 +50,19 @@ The dictionary keys for each test are described in the following table:
 | lon_range   | No                              | If set, choose a random longitude between the range provided. This will replace `{lon}` in the `url` and `text` values. |
 | click       | No                              | Selector of a DOM element to click before running a JavaScript test. |
 | delay       | No                              | Override the default number of seconds to wait between loading the page and performing a JavaScript test. |
+
+## Writing JavaScript tests
+
+As described in the table above, you must provide a chunk of JavaScript code for any test of type `javascript`. This chunk of JavaScript code must return a boolean value. For example, here's a chunk of JavaScript that is used to count the number of legend items in a Plotly legend, and returns true if there are over 5 items in the legend (and false otherwise):
+
+```
+return document.querySelectorAll('#temp-chart .legend .traces').length > 5
+```
+
+You can run this same chunk of JavaScript code in your browser's console. Simply remove the `return` statement at the beginning, and run this in your browser console:
+
+```
+document.querySelectorAll('#temp-chart .legend .traces').length > 5
+```
+
+This means you can use your browser's console to develop new tests. Just make sure to add `return` to the beginning of the chunk of JavaScript when adding it to `snap.py`, as this is needed to return the result from Selenium's web driver.

--- a/snap.py
+++ b/snap.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
+import csv
 import os
 import subprocess
 import re
+import requests
 import time
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
-
-column = "javascript"
 
 xymon = os.getenv("XYMON")
 xymsrv = os.getenv("XYMSRV")
@@ -15,56 +15,194 @@ options = Options()
 options.headless = True
 driver = webdriver.Firefox(options=options, executable_path="/usr/bin/geckodriver", service_log_path="/tmp/geckodriver.log")
 
+pass_icon = '<img src="/xymon/gifs/static/green.gif" alt="green" height="16" width="16" border="0">'
+fail_icon = '<img src="/xymon/gifs/static/red.gif" alt="green" height="16" width="16" border="0">'
+
 checks = {
     "northernclimatereports.org": [
         {
+            "column": "frontend",
+            "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
-            "test": "return _.inRange(parseFloat(document.querySelector('.report--temperature .diff').textContent.substring(1)), 0, 10)",
-            "failure": "Temperature table values are not valid."
-        }
+            "test": """
+               return _.reduce(document.querySelectorAll('.report--temperature tbody td'), (acc, cur) => {
+                    let temperature = parseFloat(cur.textContent.match(/[0-9\.]+(?=\u00b0F)/)[0])
+                    return acc && _.inRange(temperature, 0, 100)
+                })
+            """,
+            "text": "Temperature table values are valid."
+        },
+        {
+            "column": "frontend",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "test": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
+            "text": "Temperature chart is populated."
+        },
+        {
+            "column": "frontend",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "test": """
+                return _.reduce(document.querySelectorAll('#precipitation tbody td'), (acc, cur) => {
+                    let precipitation = parseFloat(cur.textContent.match(/[0-9\.]+(?=in)/)[0])
+                    return acc && _.inRange(precipitation, 0, 20)
+                })
+            """,
+            "text": "Precipitation table values are valid."
+        },
+        {
+            "column": "frontend",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "test": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
+            "text": "Precipitation chart is populated."
+        },
+        {
+            "column": "backend",
+            "type": "csv",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/temperature/point/65.0628/-146.1627?format=csv",
+            "text": "Temperature API endpoint CSV is valid."
+        },
+        {
+            "column": "backend",
+            "type": "csv",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/precipitation/point/65.0628/-146.1627?format=csv",
+            "text": "Precipitation API endpoint CSV is valid."
+        },
+        {
+            "column": "backend",
+            "type": "csv",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/permafrost/point/65.0628/-146.1627?format=csv",
+            "text": "Permafrost API endpoint CSV is valid."
+        },
+        {
+            "column": "backend",
+            "type": "csv",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/flammability/point/65.0628/-146.1627?format=csv",
+            "text": "Flammability API endpoint CSV is valid."
+        },
+        {
+            "column": "backend",
+            "type": "csv",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/veg_type/point/65.0628/-146.1627?format=csv",
+            "text": "Vegetation type API endpoint CSV is valid."
+        },
+        {
+            "column": "backend",
+            "type": "json",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/taspr/point/65.0628/-146.1627",
+            "text": "Temperature and precipitation API endpoint JSON is valid."
+        },
+        {
+            "column": "backend",
+            "type": "json",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/permafrost/point/65.0628/-146.1627",
+            "text": "Permafrost API endpoint JSON is valid."
+        },
+        {
+            "column": "backend",
+            "type": "json",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/flammability/point/65.0628/-146.1627",
+            "text": "Flammability API endpoint JSON is valid."
+        },
+        {
+            "column": "backend",
+            "type": "json",
+            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/veg_type/point/65.0628/-146.1627",
+            "text": "Vegetation type API endpoint JSON is valid."
+        },
     ],
     "production-fire-tally.us-west-2.elasticbeanstalk.com": [
         {
+            "column": "frontend",
+            "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
-            "test": "return document.querySelector('#tally .legendlines') != undefined",
-            "failure": "Statewide daily tally graph is not populated."
+            "test": "return document.querySelectorAll('#tally .legendlines').length > 5",
+            "text": "Statewide daily tally chart is populated."
         },
         {
+            "column": "frontend",
+            "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
-            "test": "return document.querySelector('#tally-zone .legendlines') != undefined",
-            "failure": "Daily tally by protection area graph is not populated."
+            "test": "return document.querySelectorAll('#tally-zone .legendlines').length > 5",
+            "text": "Daily tally by protection chart graph is populated."
         },
         {
+            "column": "frontend",
+            "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
-            "test": "return document.querySelector('#tally-year .legendlines') != undefined",
-            "failure": "Daily tally by year graph is not populated."
+            "test": "return document.querySelectorAll('#tally-year .legendlines').length > 5",
+            "text": "Daily tally by year chart is populated."
         },
     ]
 }
 
+def javascriptCheck(check):
+    try:
+        driver.get(check["url"])
+        time.sleep(10)
+        return driver.execute_script(check["test"])
+    except:
+        return False
+
+
+def csvCheck(check):
+    try:
+        response = requests.get(check["url"])
+        no_metadata = []
+        for row in response.text.split("\r\n"):
+            if len(row) > 0 and row[0] != "#":
+                no_metadata.append(row)
+        reader = csv.reader(no_metadata)
+        next(reader)
+        return True
+    except:
+        return False
+
+
+def jsonCheck(check):
+    try:
+        response = requests.get(check["url"])
+        results = response.json()
+        return True
+    except:
+        return False
+
+
+colors = {}
+messages = {}
+
 for machine in checks.keys():
-    color = "green"
-    msg = ""
     for check in checks[machine]:
-        success = True
-        try:
-            driver.get(check["url"])
-            time.sleep(5)
-            success = driver.execute_script(check["test"])
-        except:
-            success = False
-            pass
+        column = check["column"]
+        if check["column"] not in colors:
+            colors[column] = "green"
+            messages[column] = ""
 
-        if not success:
-            color = "red"
-            msg += check["failure"] + "\n"
+        if check["type"] == "javascript":
+            success = javascriptCheck(check)
+        elif check["type"] == "json":
+            success = jsonCheck(check)
+        elif check["type"] == "csv":
+            success = csvCheck(check)
 
-    if color is "green":
-        msg = "All tests passed."
+        if success == True:
+            messages[column] += pass_icon + " " + check["text"] + "\n"
+        else:
+            colors[column] = "red"
+            messages[column] += fail_icon + " " + check["text"] + "\n"
 
-    date = subprocess.check_output(["date"])
-    machine_safe = machine.replace(".", ",")
-    status = "status {}.{} {} {}\n\n{}".format(machine, column, color, date, msg)
-    subprocess.call([xymon, xymsrv, status])
+    for column in colors.keys():
+        date = subprocess.check_output(["date"])
+        machine_safe = machine.replace(".", ",")
+        status = "status {}.{} {} {}\n\n{}".format(
+            machine,
+            column,
+            colors[column],
+            date,
+            messages[column]
+        )
+        subprocess.call([xymon, xymsrv, status])
 
 driver.quit()

--- a/snap.py
+++ b/snap.py
@@ -211,10 +211,136 @@ checks = {
         },
         {
             "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=annual_precip_totals_mm&styles=precip_mm_midcentury_era&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_precip&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected precipitation map layer accessible."
+        },
+        {
+            "column": "webapp",
             "type": "javascript",
             "url": "https://arcticeds.org/climate/snowfall",
             "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
             "text": "Snowfall map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=mean_annual_snowfall_mm&styles=snowfall_mm&format=image%2Fpng&transparent=true&version=1.3.0&id=future_mean_annual_snowfall&dim_model=4&dim_scenario=3&dim_decade=18&width=256&height=256&crs=EPSG%3A3338&bbox=70586,969097,594874,1493385",
+            "text": "Projected snowfall map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=annual_mean_temp&styles=temp_midcentury_era&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_annual_mean_temp&width=256&height=256&crs=EPSG%3A3338&bbox=70586,969097,594874,1493385",
+            "text": "Projected mean annual temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=jan_min_max_mean_temp&styles=temp_historical_january_min&format=image%2Fpng&transparent=true&version=1.3.0&id=historical_era_january_min&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Historical January minimum temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=july_min_max_mean_temp&styles=temp_historical_july_min&format=image%2Fpng&transparent=true&version=1.3.0&id=historical_era_july_min&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Historical July minimum temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=jan_min_max_mean_temp&styles=temp_historical_january_max&format=image%2Fpng&transparent=true&version=1.3.0&id=historical_era_january_max&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Historical January maximum temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=july_min_max_mean_temp&styles=temp_historical_july_max&format=image%2Fpng&transparent=true&version=1.3.0&id=historical_era_july_max&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Historical July maximum temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=jan_min_max_mean_temp&styles=temp_midcentury_january_min&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_january_min&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,201767",
+            "text": "Projected January minimum temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=july_min_max_mean_temp&styles=temp_midcentury_july_min&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_july_min&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,201767",
+            "text": "Projected July minimum temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=jan_min_max_mean_temp&styles=temp_midcentury_january_max&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_january_max&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,201767",
+            "text": "Projected January maximum temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=july_min_max_mean_temp&styles=temp_midcentury_july_max&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_july_max&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected July maximum temperature map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=design_freezing_index&styles=arctic_eds&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_design_freezing_index&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected design freezing index map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=design_thawing_index&styles=arctic_eds&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_design_thawing_index&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected design thawing index map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=freezing_index&styles=arctic_eds_freezing_index_future_condensed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_freezing_index_midcentury&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected freezing index map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=thawing_index&styles=arctic_eds_thawing_index_future_condensed_compressed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_thawing_index_midcentury&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected thawing index map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=heating_degree_days&styles=arctic_eds_heating_degree_days_future_condensed_compressed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_heating_degree_days&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected heating degree days map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=permafrost_beta%3Aobu_pf_extent&styles=&format=image%2Fpng&transparent=true&version=1.3.0&id=pfextent_obu&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Permafrost extent (Obu) map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=iem_gipl_magt_alt_4km&styles=arctic_eds_MAGT&format=image%2Fpng&transparent=true&version=1.3.0&id=iem_gipl_magt_alt_4km_historical&dim_model=0&dim_scenario=0&dim_era=0&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Mean annual ground temperature (1986-2005) map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=iem_gipl_magt_alt_4km&styles=arctic_eds_MAGT&format=image%2Fpng&transparent=true&version=1.3.0&id=iem_gipl_magt_alt_4km_2036_2065&dim_model=5&dim_scenario=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Mean annual ground temperature (2036-2065) map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=obu_2018_magt&styles=ground_temperature_blue_to_red_arctic_eds&format=image%2Fpng&transparent=true&version=1.3.0&id=obumagt&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Mean annual ground temperature at top map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=permafrost_beta%3Ajorgenson_2008_pf_extent_ground_ice_volume&styles=permafrost_beta%3Aground_ice_volume&format=image%2Fpng&transparent=true&version=1.3.0&id=icevol_jorgenson&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Ground ice volume map layer accessible."
         },
         {
             "column": "webapp",
@@ -314,6 +440,14 @@ def jsonTest(check):
         return False
 
 
+def urlTest(check):
+    try:
+        response = requests.get(check["url"])
+        return response.status_code == 200
+    except:
+        return False
+
+
 for machine in checks.keys():
     colors = {}
     messages = {}
@@ -329,6 +463,8 @@ for machine in checks.keys():
             success = jsonTest(check)
         elif check["type"] == "csv":
             success = csvTest(check)
+        elif check["type"] == "url":
+            success = urlTest(check)
 
         if success == True:
             messages[column] += "&green " + check["text"] + "\n"

--- a/snap.py
+++ b/snap.py
@@ -146,8 +146,8 @@ tests = {
             "column": "webapp",
             "type": "csv",
             "url": "https://earthmaps.io/alfresco/flammability/point/{lat}/{lon}?format=csv",
-            "lat_range": [62.70, 67.92],
-            "lon_range": [-158.50, -144.21],
+            "lat_range": [63.72, 64.40],
+            "lon_range": [-157.15, -154.20],
             "text": "Flammability API endpoint CSV is valid ({lat}, {lon})."
         },
         {
@@ -178,8 +178,8 @@ tests = {
             "column": "webapp",
             "type": "json",
             "url": "https://earthmaps.io/alfresco/flammability/point/{lat}/{lon}",
-            "lat_range": [62.70, 67.92],
-            "lon_range": [-158.50, -144.21],
+            "lat_range": [63.72, 64.40],
+            "lon_range": [-157.15, -154.20],
             "text": "Flammability API endpoint JSON is valid ({lat}, {lon})."
         },
         {

--- a/snap.py
+++ b/snap.py
@@ -245,6 +245,18 @@ checks = {
         {
             "column": "webapp",
             "type": "javascript",
+            "url": "https://arcticeds.org/climate/temperature/report/63.1429/-154.9583#report",
+            "javascript": """
+               return _.reduce(document.querySelectorAll('#report tbody td'), (acc, cur) => {
+                    let temperature = parseFloat(cur.textContent.match(/[0-9\.]+(?=\u00b0F)/)[0])
+                    return acc && _.inRange(temperature, -80, 120)
+                })
+            """,
+            "text": "Temperature table populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
             "url": "https://arcticeds.org/engineering/design-freezing-index",
             "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
             "text": "Design freezing index map loaded."
@@ -333,18 +345,6 @@ checks = {
             "type": "url",
             "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=permafrost_beta%3Aobu_pf_extent&styles=&format=image%2Fpng&transparent=true&version=1.3.0&id=pfextent_obu&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
             "text": "Permafrost extent (Obu) map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "javascript",
-            "url": "https://arcticeds.org/climate/temperature/report/63.1429/-154.9583#report",
-            "javascript": """
-               return _.reduce(document.querySelectorAll('#report tbody td'), (acc, cur) => {
-                    let temperature = parseFloat(cur.textContent.match(/[0-9\.]+(?=\u00b0F)/)[0])
-                    return acc && _.inRange(temperature, -80, 120)
-                })
-            """,
-            "text": "Temperature table populated."
         },
     ],
     "seaiceatlas.snap.uaf.edu": [
@@ -582,7 +582,7 @@ checks = {
             "column": "webapp",
             "type": "javascript",
             "url": "http://windtool.accap.uaf.edu/",
-            "javascript": "return document.querySelectorAll('#future_delta_percentiles_graph g').length > 100",
+            "javascript": "return document.querySelectorAll('#future_delta_percentiles g').length > 80",
             "text": "Modeled past and future wind plot populated."
         },
         {
@@ -593,6 +593,93 @@ checks = {
             "text": "Modeled wind speed plot populated."
         },
     ],
+    "living-off-the-land.s3-website-us-west-2.amazonaws.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/living-off-the-land",
+            "javascript": "return document.querySelectorAll('#ice-and-snow__map path').length > 100",
+            "text": "Ice observations map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=nasa_above%3Awintertemp_2010s_tcc&styles=&format=image%2Fpng&transparent=true&version=1.3&srs=EPSG%3A3338&tiled=true&continuousWorld=true&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Winter temperature (2010) map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/living-off-the-land",
+            "javascript": "return document.querySelectorAll('#snowday-fraction-map__map path').length > 80",
+            "text": "Snow observations map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=nasa_above%3AOct_snowdayfraction_2010s_tcc_reprojected&styles=&format=image%2Fpng&transparent=true&version=1.3&srs=EPSG%3A3338&tiled=true&continuousWorld=true&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Snow observations (2010) map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/living-off-the-land",
+            "javascript": "return document.querySelectorAll('#permafrost-map__map path').length > 150",
+            "text": "Permafrost map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=nasa_above%3AJuly_permafrost_2m_2010s_tcc&styles=&format=image%2Fpng&transparent=true&version=1.3&srs=EPSG%3A3338&tiled=true&continuousWorld=true&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Permafrost (2010) map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/living-off-the-land",
+            "javascript": "return document.querySelectorAll('#historical-fires__map path').length > 40",
+            "text": "Historical fire map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=alaska_wildfires%3Ahistorical_fire_perimiters&styles=fire_history_70s_2010s&format=image%2Fpng&transparent=true&version=1.3&srs=EPSG%3A3338&tiled=true&continuousWorld=true&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Historical fires map layer accessible."
+        },
+    ],
+    "production-dot-precip-dash.us-west-2.elasticbeanstalk.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/future-alaska-precip",
+            "javascript": "return document.querySelectorAll('#ak-map .leaflet-tile').length > 10",
+            "text": "Map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/future-alaska-precip",
+            "click": "#ak-map",
+            "click_delay": 30,
+            "javascript": "return document.querySelectorAll('#pf-data-tables tr').length > 10",
+            "text": "Table populated."
+        },
+    ],
+    "production-swti.eba-spvr3kbd.us-west-2.elasticbeanstalk.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://accap.uaf.edu/tools/statewide-temperature-index",
+            "javascript": "return document.querySelectorAll('#daily-index .traces').length > 1",
+            "text": "Chart populated."
+        },
+        {
+            "column": "webapp",
+            "type": "csv",
+            "url": "https://accap.uaf.edu/tools/statewide-temperature-index/downloads/statewide_temperature_daily_index.csv",
+            "text": "CSV is valid."
+        },
+    ]
 }
 
 def javascriptTest(check):
@@ -602,7 +689,10 @@ def javascriptTest(check):
         if "click" in check:
             elementToClick = driver.find_element(By.CSS_SELECTOR, check["click"])
             elementToClick.click()
-            time.sleep(10) 
+            if "click_delay" in check:
+                time.sleep(check["click_delay"]) 
+            else:
+                time.sleep(10) 
         return driver.execute_script(check["javascript"])
     except:
         return False
@@ -612,7 +702,7 @@ def csvTest(check):
     try:
         response = requests.get(check["url"])
         no_metadata = []
-        for row in response.text.split("\r\n"):
+        for row in re.split("\r?\n", response.text):
             if len(row) > 0 and row[0] != "#":
                 no_metadata.append(row)
         reader = csv.reader(no_metadata)

--- a/snap.py
+++ b/snap.py
@@ -24,7 +24,7 @@ checks = {
             "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
-            "test": """
+            "javascript": """
                return _.reduce(document.querySelectorAll('.report--temperature tbody td'), (acc, cur) => {
                     let temperature = parseFloat(cur.textContent.match(/[0-9\.]+(?=\u00b0F)/)[0])
                     return acc && _.inRange(temperature, 0, 100)
@@ -36,14 +36,14 @@ checks = {
             "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
-            "test": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
+            "javascript": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
             "text": "Temperature chart is populated."
         },
         {
             "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
-            "test": """
+            "javascript": """
                 return _.reduce(document.querySelectorAll('#precipitation tbody td'), (acc, cur) => {
                     let precipitation = parseFloat(cur.textContent.match(/[0-9\.]+(?=in)/)[0])
                     return acc && _.inRange(precipitation, 0, 20)
@@ -55,7 +55,68 @@ checks = {
             "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
-            "test": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
+            "javascript": """
+                return _.filter(document.querySelectorAll('#permafrost .leaflet-tile-loaded'), (tile) => {
+                    return tile.src.indexOf('gipl') != -1
+                }).length > 20
+            """,
+            "text": "Permafrost mini-maps loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "javascript": "return document.querySelectorAll('#permafrost-alt-thaw-chart .legend .traces').length > 5",
+            "text": "Permafrost active layer thickness chart is populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "javascript": "return document.querySelectorAll('#permafrost-alt-freeze-chart .legend .traces').length > 5",
+            "text": "Permafrost ground freeze depth chart is populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "javascript": """
+                return _.filter(document.querySelectorAll('#wildfire .leaflet-tile-loaded'), (tile) => {
+                    return tile.src.indexOf('flammability') != -1
+                }).length > 20
+            """,
+            "text": "Flammability mini-maps loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "javascript": "return document.querySelectorAll('#wildfire-flammability-chart .legend .traces').length > 5",
+            "text": "Flammability chart is populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "javascript": """
+                return _.filter(document.querySelectorAll('#wildfire .leaflet-tile-loaded'), (tile) => {
+                    return tile.src.indexOf('vegetation') != -1
+                }).length > 20
+            """,
+            "text": "Vegetation type mini-maps loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "javascript": "return document.querySelectorAll('#wildfire-veg-change-chart .legend .traces').length > 5",
+            "text": "Vegetation type chart is populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "javascript": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
             "text": "Precipitation chart is populated."
         },
         {
@@ -111,43 +172,43 @@ checks = {
             "type": "json",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/veg_type/point/65.0628/-146.1627",
             "text": "Vegetation type API endpoint JSON is valid."
-        },
+        }
     ],
     "production-fire-tally.us-west-2.elasticbeanstalk.com": [
         {
             "column": "webapp",
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
-            "test": "return document.querySelectorAll('#tally .legendlines').length > 5",
+            "javascript": "return document.querySelectorAll('#tally .legendlines').length > 5",
             "text": "Statewide daily tally chart is populated."
         },
         {
             "column": "webapp",
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
-            "test": "return document.querySelectorAll('#tally-zone .legendlines').length > 5",
+            "javascript": "return document.querySelectorAll('#tally-zone .legendlines').length > 5",
             "text": "Daily tally by protection chart graph is populated."
         },
         {
             "column": "webapp",
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
-            "test": "return document.querySelectorAll('#tally-year .legendlines').length > 5",
+            "javascript": "return document.querySelectorAll('#tally-year .legendlines').length > 5",
             "text": "Daily tally by year chart is populated."
         },
     ]
 }
 
-def javascriptCheck(check):
+def javascriptTest(check):
     try:
         driver.get(check["url"])
         time.sleep(10)
-        return driver.execute_script(check["test"])
+        return driver.execute_script(check["javascript"])
     except:
         return False
 
 
-def csvCheck(check):
+def csvTest(check):
     try:
         response = requests.get(check["url"])
         no_metadata = []
@@ -161,7 +222,7 @@ def csvCheck(check):
         return False
 
 
-def jsonCheck(check):
+def jsonTest(check):
     try:
         response = requests.get(check["url"])
         results = response.json()
@@ -180,11 +241,11 @@ for machine in checks.keys():
             messages[column] = ""
 
         if check["type"] == "javascript":
-            success = javascriptCheck(check)
+            success = javascriptTest(check)
         elif check["type"] == "json":
-            success = jsonCheck(check)
+            success = jsonTest(check)
         elif check["type"] == "csv":
-            success = csvCheck(check)
+            success = csvTest(check)
 
         if success == True:
             messages[column] += pass_icon + " " + check["text"] + "\n"

--- a/snap.py
+++ b/snap.py
@@ -36,7 +36,7 @@ checks = {
             "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
-            "javascript": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
+            "javascript": "return document.querySelectorAll('#temp-chart .legend .traces').length > 5",
             "text": "Temperature chart is populated."
         },
         {
@@ -50,6 +50,13 @@ checks = {
                 })
             """,
             "text": "Precipitation table values are valid."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "javascript": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
+            "text": "Precipitation chart is populated."
         },
         {
             "column": "webapp",
@@ -196,7 +203,86 @@ checks = {
             "javascript": "return document.querySelectorAll('#tally-year .legendlines').length > 5",
             "text": "Daily tally by year chart is populated."
         },
-    ]
+    ],
+    "arcticeds.org": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/climate/precipitation",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Precipitation map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/climate/snowfall",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Snowfall map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/climate/temperature",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Temperature map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/engineering/design-freezing-index",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Design freezing index map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/engineering/design-thawing-index",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Design thawing index map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/engineering/freezing-index",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Freezing index map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/engineering/thawing-index",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Thawing index map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/engineering/heating-degree-days",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Heating degree days map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/physiography/ecoregions",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Ecoregions map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/physiography/geology",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Geology map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/physiography/permafrost",
+            "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
+            "text": "Permafrost map loaded."
+        },
+    ],
 }
 
 def javascriptTest(check):

--- a/snap.py
+++ b/snap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 import csv
 import os
 import subprocess
@@ -15,13 +15,13 @@ options = Options()
 options.headless = True
 driver = webdriver.Firefox(options=options, executable_path="/usr/bin/geckodriver", service_log_path="/tmp/geckodriver.log")
 
-pass_icon = '<img src="/xymon/gifs/static/green.gif" alt="green" height="16" width="16" border="0">'
-fail_icon = '<img src="/xymon/gifs/static/red.gif" alt="green" height="16" width="16" border="0">'
+pass_icon = '<img src="/xymon/gifs/green.gif" alt="green" height="16" width="16" border="0">'
+fail_icon = '<img src="/xymon/gifs/red.gif" alt="green" height="16" width="16" border="0">'
 
 checks = {
     "northernclimatereports.org": [
         {
-            "column": "frontend",
+            "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
             "test": """
@@ -33,14 +33,14 @@ checks = {
             "text": "Temperature table values are valid."
         },
         {
-            "column": "frontend",
+            "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
             "test": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
             "text": "Temperature chart is populated."
         },
         {
-            "column": "frontend",
+            "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
             "test": """
@@ -52,62 +52,62 @@ checks = {
             "text": "Precipitation table values are valid."
         },
         {
-            "column": "frontend",
+            "column": "webapp",
             "type": "javascript",
             "url": "https://northernclimatereports.org/report/community/AK124#results",
             "test": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
             "text": "Precipitation chart is populated."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "csv",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/temperature/point/65.0628/-146.1627?format=csv",
             "text": "Temperature API endpoint CSV is valid."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "csv",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/precipitation/point/65.0628/-146.1627?format=csv",
             "text": "Precipitation API endpoint CSV is valid."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "csv",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/permafrost/point/65.0628/-146.1627?format=csv",
             "text": "Permafrost API endpoint CSV is valid."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "csv",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/flammability/point/65.0628/-146.1627?format=csv",
             "text": "Flammability API endpoint CSV is valid."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "csv",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/veg_type/point/65.0628/-146.1627?format=csv",
             "text": "Vegetation type API endpoint CSV is valid."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "json",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/taspr/point/65.0628/-146.1627",
             "text": "Temperature and precipitation API endpoint JSON is valid."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "json",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/permafrost/point/65.0628/-146.1627",
             "text": "Permafrost API endpoint JSON is valid."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "json",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/flammability/point/65.0628/-146.1627",
             "text": "Flammability API endpoint JSON is valid."
         },
         {
-            "column": "backend",
+            "column": "webapp",
             "type": "json",
             "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/veg_type/point/65.0628/-146.1627",
             "text": "Vegetation type API endpoint JSON is valid."
@@ -115,21 +115,21 @@ checks = {
     ],
     "production-fire-tally.us-west-2.elasticbeanstalk.com": [
         {
-            "column": "frontend",
+            "column": "webapp",
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
             "test": "return document.querySelectorAll('#tally .legendlines').length > 5",
             "text": "Statewide daily tally chart is populated."
         },
         {
-            "column": "frontend",
+            "column": "webapp",
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
             "test": "return document.querySelectorAll('#tally-zone .legendlines').length > 5",
             "text": "Daily tally by protection chart graph is populated."
         },
         {
-            "column": "frontend",
+            "column": "webapp",
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/daily-fire-tally",
             "test": "return document.querySelectorAll('#tally-year .legendlines').length > 5",
@@ -170,10 +170,9 @@ def jsonCheck(check):
         return False
 
 
-colors = {}
-messages = {}
-
 for machine in checks.keys():
+    colors = {}
+    messages = {}
     for check in checks[machine]:
         column = check["column"]
         if check["column"] not in colors:
@@ -194,9 +193,9 @@ for machine in checks.keys():
             messages[column] += fail_icon + " " + check["text"] + "\n"
 
     for column in colors.keys():
-        date = subprocess.check_output(["date"])
+        date = subprocess.check_output(["date"]).decode("ascii")
         machine_safe = machine.replace(".", ",")
-        status = "status {}.{} {} {}\n\n{}".format(
+        status = "status {}.{} {} {}\n{}".format(
             machine,
             column,
             colors[column],

--- a/snap.py
+++ b/snap.py
@@ -465,8 +465,8 @@ tests = {
             "column": "webapp",
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/alaska-wildfires",
-            "javascript": "return document.querySelectorAll('#map--leaflet-map path').length > 1",
-            "text": "Wildfire map populated."
+            "javascript": "return document.querySelectorAll('#map--leaflet-map path').length > 1 || document.querySelectorAll('.intro').length == 0",
+            "text": "Wildfire map populated or inactive."
         },
         {
             "column": "webapp",

--- a/snap.py
+++ b/snap.py
@@ -15,9 +15,6 @@ options = Options()
 options.headless = True
 driver = webdriver.Firefox(options=options, executable_path="/usr/bin/geckodriver", service_log_path="/tmp/geckodriver.log")
 
-pass_icon = '<img src="/xymon/gifs/green.gif" alt="green" height="16" width="16" border="0">'
-fail_icon = '<img src="/xymon/gifs/red.gif" alt="green" height="16" width="16" border="0">'
-
 checks = {
     "northernclimatereports.org": [
         {
@@ -86,7 +83,7 @@ checks = {
         {
             "column": "webapp",
             "type": "javascript",
-            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "url": "https://northernclimatereports.org/report_bad/community/AK124#results",
             "javascript": """
                 return _.filter(document.querySelectorAll('#wildfire .leaflet-tile-loaded'), (tile) => {
                     return tile.src.indexOf('flammability') != -1
@@ -334,10 +331,10 @@ for machine in checks.keys():
             success = csvTest(check)
 
         if success == True:
-            messages[column] += pass_icon + " " + check["text"] + "\n"
+            messages[column] += "&green " + check["text"] + "\n"
         else:
             colors[column] = "red"
-            messages[column] += fail_icon + " " + check["text"] + "\n"
+            messages[column] += "&red " + check["text"] + "\n"
 
     for column in colors.keys():
         date = subprocess.check_output(["date"]).decode("ascii")

--- a/snap.py
+++ b/snap.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import re
+import time
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
+
+column = "javascript"
+
+xymon = os.getenv("XYMON")
+xymsrv = os.getenv("XYMSRV")
+
+options = Options()
+options.headless = True
+driver = webdriver.Firefox(options=options, executable_path="/usr/bin/geckodriver", service_log_path="/tmp/geckodriver.log")
+
+checks = {
+    "northernclimatereports.org": [
+        {
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
+            "test": "return _.inRange(parseFloat(document.querySelector('.report--temperature .diff').textContent.substring(1)), 0, 10)",
+            "failure": "Temperature table values are not valid."
+        }
+    ],
+    "production-fire-tally.us-west-2.elasticbeanstalk.com": [
+        {
+            "url": "https://snap.uaf.edu/tools/daily-fire-tally",
+            "test": "return document.querySelector('#tally .legendlines') != undefined",
+            "failure": "Statewide daily tally graph is not populated."
+        },
+        {
+            "url": "https://snap.uaf.edu/tools/daily-fire-tally",
+            "test": "return document.querySelector('#tally-zone .legendlines') != undefined",
+            "failure": "Daily tally by protection area graph is not populated."
+        },
+        {
+            "url": "https://snap.uaf.edu/tools/daily-fire-tally",
+            "test": "return document.querySelector('#tally-year .legendlines') != undefined",
+            "failure": "Daily tally by year graph is not populated."
+        },
+    ]
+}
+
+for machine in checks.keys():
+    color = "green"
+    msg = ""
+    for check in checks[machine]:
+        success = True
+        try:
+            driver.get(check["url"])
+            time.sleep(5)
+            success = driver.execute_script(check["test"])
+        except:
+            success = False
+            pass
+
+        if not success:
+            color = "red"
+            msg += check["failure"] + "\n"
+
+    if color is "green":
+        msg = "All tests passed."
+
+    date = subprocess.check_output(["date"])
+    machine_safe = machine.replace(".", ",")
+    status = "status {}.{} {} {}\n\n{}".format(machine, column, color, date, msg)
+    subprocess.call([xymon, xymsrv, status])
+
+driver.quit()

--- a/snap.py
+++ b/snap.py
@@ -438,7 +438,8 @@ tests = {
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/gardenhelper",
             "javascript": "return document.querySelectorAll('#tcharts g').length > 100",
-            "text": "Growing season chart populated."
+            "text": "Growing season chart populated.",
+            "delay": 60
         },
         {
             "column": "webapp",
@@ -447,6 +448,7 @@ tests = {
             "click": ".tab:nth-of-type(2)",
             "javascript": "return document.querySelectorAll('#acharts path').length > 1000",
             "text": "Annual minimums chart populated."
+            "delay": 60
         },
         {
             "column": "webapp",
@@ -455,6 +457,7 @@ tests = {
             "click": ".tab:nth-of-type(3)",
             "javascript": "return document.querySelectorAll('#ccharts .legendlines').length > 10",
             "text": "Growing degree days chart populated."
+            "delay": 60
         },
     ],
     "production-alaska-wildfires.s3-website-us-west-2.amazonaws.com": [

--- a/snap.py
+++ b/snap.py
@@ -447,7 +447,7 @@ tests = {
             "url": "https://snap.uaf.edu/tools/gardenhelper",
             "click": ".tab:nth-of-type(2)",
             "javascript": "return document.querySelectorAll('#acharts path').length > 1000",
-            "text": "Annual minimums chart populated."
+            "text": "Annual minimums chart populated.",
             "delay": 60
         },
         {
@@ -456,7 +456,7 @@ tests = {
             "url": "https://snap.uaf.edu/tools/gardenhelper",
             "click": ".tab:nth-of-type(3)",
             "javascript": "return document.querySelectorAll('#ccharts .legendlines').length > 10",
-            "text": "Growing degree days chart populated."
+            "text": "Growing degree days chart populated.",
             "delay": 60
         },
     ],

--- a/snap.py
+++ b/snap.py
@@ -83,7 +83,7 @@ checks = {
         {
             "column": "webapp",
             "type": "javascript",
-            "url": "https://northernclimatereports.org/report_bad/community/AK124#results",
+            "url": "https://northernclimatereports.org/report/community/AK124#results",
             "javascript": """
                 return _.filter(document.querySelectorAll('#wildfire .leaflet-tile-loaded'), (tile) => {
                     return tile.src.indexOf('flammability') != -1

--- a/snap.py
+++ b/snap.py
@@ -382,7 +382,7 @@ tests = {
             "column": "webapp",
             "type": "json",
             "url": "https://earthmaps.io/seaice/point/{lat}/{lon}/",
-            "lat_range": [70.65, 73.60],
+            "lat_range": [71.50, 73.60],
             "lon_range": [-177.5, -131.41],
             "text": "Sea ice API endpoint JSON is valid."
         },
@@ -390,7 +390,7 @@ tests = {
             "column": "webapp",
             "type": "csv",
             "url": "https://earthmaps.io/seaice/point/{lat}/{lon}?format=csv",
-            "lat_range": [70.65, 73.60],
+            "lat_range": [71.50, 73.60],
             "lon_range": [-177.5, -131.41],
             "text": "Sea ice API endpoint CSV is valid at {lat}, {lon}."
         },

--- a/snap.py
+++ b/snap.py
@@ -2,6 +2,7 @@
 import csv
 import os
 import subprocess
+import random
 import re
 import requests
 import time
@@ -24,8 +25,8 @@ checks = {
             "url": "https://northernclimatereports.org/report/community/AK124#results",
             "javascript": """
                return _.reduce(document.querySelectorAll('.report--temperature tbody td'), (acc, cur) => {
-                    let temperature = parseFloat(cur.textContent.match(/[0-9\.]+(?=\u00b0F)/)[0])
-                    return acc && _.inRange(temperature, 0, 100)
+                    let temperature = parseFloat(cur.textContent.match(/[\-0-9\.]+(?=\u00b0F)/)[0])
+                    return acc && _.inRange(temperature, -60, 100)
                 })
             """,
             "text": "Temperature table values are valid."
@@ -48,13 +49,6 @@ checks = {
                 })
             """,
             "text": "Precipitation table values are valid."
-        },
-        {
-            "column": "webapp",
-            "type": "javascript",
-            "url": "https://northernclimatereports.org/report/community/AK124#results",
-            "javascript": "return document.querySelectorAll('#precip-chart .legend .traces').length > 5",
-            "text": "Precipitation chart is populated."
         },
         {
             "column": "webapp",
@@ -127,56 +121,74 @@ checks = {
         {
             "column": "webapp",
             "type": "csv",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/temperature/point/65.0628/-146.1627?format=csv",
-            "text": "Temperature API endpoint CSV is valid."
+            "url": "https://earthmaps.io/temperature/point/{lat}/{lon}?format=csv",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Temperature API endpoint CSV is valid ({lat}, {lon})."
         },
         {
             "column": "webapp",
             "type": "csv",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/precipitation/point/65.0628/-146.1627?format=csv",
-            "text": "Precipitation API endpoint CSV is valid."
+            "url": "https://earthmaps.io/precipitation/point/{lat}/{lon}?format=csv",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Precipitation API endpoint CSV is valid ({lat}, {lon})."
         },
         {
             "column": "webapp",
             "type": "csv",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/permafrost/point/65.0628/-146.1627?format=csv",
-            "text": "Permafrost API endpoint CSV is valid."
+            "url": "https://earthmaps.io/permafrost/point/{lat}/{lon}?format=csv",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Permafrost API endpoint CSV is valid ({lat}, {lon})."
         },
         {
             "column": "webapp",
             "type": "csv",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/flammability/point/65.0628/-146.1627?format=csv",
-            "text": "Flammability API endpoint CSV is valid."
+            "url": "https://earthmaps.io/alfresco/flammability/point/{lat}/{lon}?format=csv",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Flammability API endpoint CSV is valid ({lat}, {lon})."
         },
         {
             "column": "webapp",
             "type": "csv",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/veg_type/point/65.0628/-146.1627?format=csv",
-            "text": "Vegetation type API endpoint CSV is valid."
+            "url": "https://earthmaps.io/alfresco/veg_type/point/{lat}/{lon}?format=csv",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Vegetation type API endpoint CSV is valid ({lat}, {lon})."
         },
         {
             "column": "webapp",
             "type": "json",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/taspr/point/65.0628/-146.1627",
-            "text": "Temperature and precipitation API endpoint JSON is valid."
+            "url": "https://earthmaps.io/taspr/point/{lat}/{lon}",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Temperature and precipitation API endpoint JSON is valid ({lat}, {lon})."
         },
         {
             "column": "webapp",
             "type": "json",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/permafrost/point/65.0628/-146.1627",
-            "text": "Permafrost API endpoint JSON is valid."
+            "url": "https://earthmaps.io/permafrost/point/{lat}/{lon}",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Permafrost API endpoint JSON is valid ({lat}, {lon})."
         },
         {
             "column": "webapp",
             "type": "json",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/flammability/point/65.0628/-146.1627",
-            "text": "Flammability API endpoint JSON is valid."
+            "url": "https://earthmaps.io/alfresco/flammability/point/{lat}/{lon}",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Flammability API endpoint JSON is valid ({lat}, {lon})."
         },
         {
             "column": "webapp",
             "type": "json",
-            "url": "http://ec2-52-34-170-176.us-west-2.compute.amazonaws.com/alfresco/veg_type/point/65.0628/-146.1627",
-            "text": "Vegetation type API endpoint JSON is valid."
+            "url": "https://earthmaps.io/alfresco/veg_type/point/{lat}/{lon}",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
+            "text": "Vegetation type API endpoint JSON is valid ({lat}, {lon})."
         }
     ],
     "production-fire-tally.us-west-2.elasticbeanstalk.com": [
@@ -245,14 +257,16 @@ checks = {
         {
             "column": "webapp",
             "type": "javascript",
-            "url": "https://arcticeds.org/climate/temperature/report/63.1429/-154.9583#report",
+            "url": "https://arcticeds.org/climate/temperature/report/{lat}/{lon}#report",
+            "lat_range": [62.70, 67.92],
+            "lon_range": [-158.50, -144.21],
             "javascript": """
                return _.reduce(document.querySelectorAll('#report tbody td'), (acc, cur) => {
-                    let temperature = parseFloat(cur.textContent.match(/[0-9\.]+(?=\u00b0F)/)[0])
+                    let temperature = parseFloat(cur.textContent.match(/[\-0-9\.]+(?=\u00b0F)/)[0])
                     return acc && _.inRange(temperature, -80, 120)
                 })
             """,
-            "text": "Temperature table populated."
+            "text": "Temperature table populated ({lat}, {lon})."
         },
         {
             "column": "webapp",
@@ -366,14 +380,18 @@ checks = {
         {
             "column": "webapp",
             "type": "json",
-            "url": "https://earthmaps.io/seaice/point/67.19/-167.69/",
+            "url": "https://earthmaps.io/seaice/point/{lat}/{lon}/",
+            "lat_range": [70.65, 73.60],
+            "lon_range": [-177.5, -131.41],
             "text": "Sea ice API endpoint JSON is valid."
         },
         {
             "column": "webapp",
             "type": "csv",
-            "url": "https://earthmaps.io/seaice/point/67.19/-167.69?format=csv",
-            "text": "Sea ice API endpoint CSV is valid."
+            "url": "https://earthmaps.io/seaice/point/{lat}/{lon}?format=csv",
+            "lat_range": [70.65, 73.60],
+            "lon_range": [-177.5, -131.41],
+            "text": "Sea ice API endpoint CSV is valid at {lat}, {lon}."
         },
     ],
     "production-wrcc-wind-tool.us-west-2.elasticbeanstalk.com": [
@@ -682,6 +700,21 @@ checks = {
     ]
 }
 
+
+def processCoords(check):
+    if "lat_range" not in check or "lon_range" not in check:
+        return check
+
+    lat_range = check["lat_range"]
+    lon_range = check["lon_range"]
+    coords = {}
+    coords["lat"] = round(random.uniform(lat_range[0], lat_range[1]), 2)
+    coords["lon"] = round(random.uniform(lon_range[0], lon_range[1]), 2)
+    check["url"] = check["url"].format(**coords)
+    check["text"] = check["text"].format(**coords)
+    return check
+
+
 def javascriptTest(check):
     try:
         driver.get(check["url"])
@@ -701,6 +734,8 @@ def javascriptTest(check):
 def csvTest(check):
     try:
         response = requests.get(check["url"])
+        if response.status_code != 200:
+            return False
         no_metadata = []
         for row in re.split("\r?\n", response.text):
             if len(row) > 0 and row[0] != "#":
@@ -715,6 +750,8 @@ def csvTest(check):
 def jsonTest(check):
     try:
         response = requests.get(check["url"])
+        if response.status_code != 200:
+            return False
         results = response.json()
         return True
     except:
@@ -737,6 +774,8 @@ for machine in checks.keys():
         if check["column"] not in colors:
             colors[column] = "green"
             messages[column] = ""
+
+        check = processCoords(check)
 
         if check["type"] == "javascript":
             success = javascriptTest(check)

--- a/snap.py
+++ b/snap.py
@@ -6,6 +6,7 @@ import re
 import requests
 import time
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options
 
 xymon = os.getenv("XYMON")
@@ -230,124 +231,16 @@ checks = {
         },
         {
             "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=annual_mean_temp&styles=temp_midcentury_era&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_annual_mean_temp&width=256&height=256&crs=EPSG%3A3338&bbox=70586,969097,594874,1493385",
-            "text": "Projected mean annual temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=jan_min_max_mean_temp&styles=temp_historical_january_min&format=image%2Fpng&transparent=true&version=1.3.0&id=historical_era_january_min&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Historical January minimum temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=july_min_max_mean_temp&styles=temp_historical_july_min&format=image%2Fpng&transparent=true&version=1.3.0&id=historical_era_july_min&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Historical July minimum temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=jan_min_max_mean_temp&styles=temp_historical_january_max&format=image%2Fpng&transparent=true&version=1.3.0&id=historical_era_january_max&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Historical January maximum temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=july_min_max_mean_temp&styles=temp_historical_july_max&format=image%2Fpng&transparent=true&version=1.3.0&id=historical_era_july_max&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Historical July maximum temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=jan_min_max_mean_temp&styles=temp_midcentury_january_min&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_january_min&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,201767",
-            "text": "Projected January minimum temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=july_min_max_mean_temp&styles=temp_midcentury_july_min&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_july_min&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,201767",
-            "text": "Projected July minimum temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=jan_min_max_mean_temp&styles=temp_midcentury_january_max&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_january_max&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,201767",
-            "text": "Projected January maximum temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=july_min_max_mean_temp&styles=temp_midcentury_july_max&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_july_max&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Projected July maximum temperature map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=design_freezing_index&styles=arctic_eds&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_design_freezing_index&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Projected design freezing index map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=design_thawing_index&styles=arctic_eds&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_design_thawing_index&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Projected design thawing index map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=freezing_index&styles=arctic_eds_freezing_index_future_condensed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_freezing_index_midcentury&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Projected freezing index map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=thawing_index&styles=arctic_eds_thawing_index_future_condensed_compressed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_thawing_index_midcentury&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Projected thawing index map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=heating_degree_days&styles=arctic_eds_heating_degree_days_future_condensed_compressed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_heating_degree_days&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Projected heating degree days map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=permafrost_beta%3Aobu_pf_extent&styles=&format=image%2Fpng&transparent=true&version=1.3.0&id=pfextent_obu&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Permafrost extent (Obu) map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=iem_gipl_magt_alt_4km&styles=arctic_eds_MAGT&format=image%2Fpng&transparent=true&version=1.3.0&id=iem_gipl_magt_alt_4km_historical&dim_model=0&dim_scenario=0&dim_era=0&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Mean annual ground temperature (1986-2005) map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=iem_gipl_magt_alt_4km&styles=arctic_eds_MAGT&format=image%2Fpng&transparent=true&version=1.3.0&id=iem_gipl_magt_alt_4km_2036_2065&dim_model=5&dim_scenario=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Mean annual ground temperature (2036-2065) map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=obu_2018_magt&styles=ground_temperature_blue_to_red_arctic_eds&format=image%2Fpng&transparent=true&version=1.3.0&id=obumagt&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Mean annual ground temperature at top map layer accessible."
-        },
-        {
-            "column": "webapp",
-            "type": "url",
-            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=permafrost_beta%3Ajorgenson_2008_pf_extent_ground_ice_volume&styles=permafrost_beta%3Aground_ice_volume&format=image%2Fpng&transparent=true&version=1.3.0&id=icevol_jorgenson&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
-            "text": "Ground ice volume map layer accessible."
-        },
-        {
-            "column": "webapp",
             "type": "javascript",
             "url": "https://arcticeds.org/climate/temperature",
             "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
             "text": "Temperature map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=annual_mean_temp&styles=temp_midcentury_era&format=image%2Fpng&transparent=true&version=1.3.0&id=midcentury_era_annual_mean_temp&width=256&height=256&crs=EPSG%3A3338&bbox=70586,969097,594874,1493385",
+            "text": "Projected mean annual temperature map layer accessible."
         },
         {
             "column": "webapp",
@@ -358,10 +251,22 @@ checks = {
         },
         {
             "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=design_freezing_index&styles=arctic_eds&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_design_freezing_index&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected design freezing index map layer accessible."
+        },
+        {
+            "column": "webapp",
             "type": "javascript",
             "url": "https://arcticeds.org/engineering/design-thawing-index",
             "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
             "text": "Design thawing index map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=design_thawing_index&styles=arctic_eds&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_design_thawing_index&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected design thawing index map layer accessible."
         },
         {
             "column": "webapp",
@@ -372,6 +277,12 @@ checks = {
         },
         {
             "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=freezing_index&styles=arctic_eds_freezing_index_future_condensed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_freezing_index_midcentury&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected freezing index map layer accessible."
+        },
+        {
+            "column": "webapp",
             "type": "javascript",
             "url": "https://arcticeds.org/engineering/thawing-index",
             "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
@@ -379,10 +290,22 @@ checks = {
         },
         {
             "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=thawing_index&styles=arctic_eds_thawing_index_future_condensed_compressed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_thawing_index_midcentury&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected thawing index map layer accessible."
+        },
+        {
+            "column": "webapp",
             "type": "javascript",
             "url": "https://arcticeds.org/engineering/heating-degree-days",
             "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
             "text": "Heating degree days map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://zeus.snap.uaf.edu/rasdaman/ows?service=WMS&request=GetMap&layers=heating_degree_days&styles=arctic_eds_heating_degree_days_future_condensed_compressed&format=image%2Fpng&transparent=true&version=1.3.0&id=ncarccsm4_heating_degree_days&dim_model=2&dim_era=2&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Projected heating degree days map layer accessible."
         },
         {
             "column": "webapp",
@@ -405,6 +328,270 @@ checks = {
             "javascript": "return document.querySelectorAll('#map .leaflet-tile-loaded').length > 20",
             "text": "Permafrost map loaded."
         },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=permafrost_beta%3Aobu_pf_extent&styles=&format=image%2Fpng&transparent=true&version=1.3.0&id=pfextent_obu&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Permafrost extent (Obu) map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://arcticeds.org/climate/temperature/report/63.1429/-154.9583#report",
+            "javascript": """
+               return _.reduce(document.querySelectorAll('#report tbody td'), (acc, cur) => {
+                    let temperature = parseFloat(cur.textContent.match(/[0-9\.]+(?=\u00b0F)/)[0])
+                    return acc && _.inRange(temperature, -80, 120)
+                })
+            """,
+            "text": "Temperature table populated."
+        },
+    ],
+    "seaiceatlas.snap.uaf.edu": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://www.snap.uaf.edu/tools/sea-ice-atlas",
+            "javascript": "return document.querySelectorAll('#map--main .leaflet-tile-loaded').length > 20",
+            "text": "Sea ice map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://www.snap.uaf.edu/tools/sea-ice-atlas",
+            "click": "#map--main",
+            "javascript": "return document.querySelectorAll('.js-line').length > 0",
+            "text": "Sea ice chart populated."
+        },
+        {
+            "column": "webapp",
+            "type": "json",
+            "url": "https://earthmaps.io/seaice/point/67.19/-167.69/",
+            "text": "Sea ice API endpoint JSON is valid."
+        },
+        {
+            "column": "webapp",
+            "type": "csv",
+            "url": "https://earthmaps.io/seaice/point/67.19/-167.69?format=csv",
+            "text": "Sea ice API endpoint CSV is valid."
+        },
+    ],
+    "production-wrcc-wind-tool.us-west-2.elasticbeanstalk.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/airport-winds",
+            "javascript": "return document.querySelectorAll('#map canvas').length > 1",
+            "text": "Airport map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/airport-winds",
+            "javascript": "return document.querySelectorAll('#rose g').length > 100",
+            "text": "Rose chart populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/airport-winds",
+            "javascript": "return document.querySelectorAll('#rose_monthly g').length > 1000",
+            "text": "Rose monthly charts populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/airport-winds",
+            "javascript": "return document.querySelectorAll('#exceedance_plot g').length > 80",
+            "text": "Exceedence chart populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/airport-winds",
+            "javascript": "return document.querySelectorAll('#wep_box path').length > 15",
+            "text": "Wind energy potential chart populated."
+        },
+    ],
+    "production-usda-dash.us-west-2.elasticbeanstalk.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/gardenhelper",
+            "javascript": "return document.querySelectorAll('#tcharts g').length > 100",
+            "text": "Growing season chart populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/gardenhelper",
+            "click": ".tab:nth-of-type(2)",
+            "javascript": "return document.querySelectorAll('#acharts path').length > 1000",
+            "text": "Annual minimums chart populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/gardenhelper",
+            "click": ".tab:nth-of-type(3)",
+            "javascript": "return document.querySelectorAll('#ccharts .legendlines').length > 10",
+            "text": "Growing degree days chart populated."
+        },
+    ],
+    "production-alaska-wildfires.s3-website-us-west-2.amazonaws.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/alaska-wildfires",
+            "javascript": "return document.querySelectorAll('#map--leaflet-map path').length > 1",
+            "text": "Wildfire map populated."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=postgis_lightning&styles=&format=image%2Fpng&transparent=true&version=1.3&continuousWorld=true&tiled=true&srs=EPSG%3A3338&time=&id=postgis_lightning&width=256&height=256&crs=EPSG%3A3338&bbox=594874,969097506,1119162,1493385",
+            "text": "Lightning strikes map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=alaska_wildfires%3Aspruceadj_3338&styles=alaska_wildfires%3Aspruce_adjective&format=image%2Fpng&transparent=true&version=1.3&continuousWorld=true&tiled=true&srs=EPSG%3A3338&time=&id=spruceadj_3338&width=256&height=256&crs=EPSG%3A3338&bbox=-453701,444809,70586,969097",
+            "text": "Fire danger ratings map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=alaska_wildfires%3Asnow_cover_3338&styles=alaska_wildfires%3Asnow_cover&format=image%2Fpng&transparent=true&version=1.3&continuousWorld=true&tiled=true&srs=EPSG%3A3338&time=&id=snow_cover_3338&width=256&height=256&crs=EPSG%3A3338&bbox=-453701,969097,70586,1493385",
+            "text": "Snow cover map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=alaska_wildfires%3Aalaska_landcover_2015&styles=&format=image%2Fpng&transparent=true&version=1.3&continuousWorld=true&tiled=true&srs=EPSG%3A3338&time=&id=alaska_landcover_2015&width=256&height=256&crs=EPSG%3A3338&bbox=-453701,969097,70586,1493385",
+            "text": "Land cover types map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=alaska_wildfires%3Alightning-monthly-climatology&styles=&format=image%2Fpng&transparent=true&version=1.3&continuousWorld=true&tiled=true&srs=EPSG%3A3338&time=2015-5-01T00%3A00%3A00Z&id=gridded_lightning&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Historical lightning strikes map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=historical_fire_perimiters&styles=historical_fire_polygon_buckets&format=image%2Fpng&transparent=true&version=1.3&continuousWorld=true&tiled=true&srs=EPSG%3A3338&time=&id=historical_fire_perimiters&width=256&height=256&crs=EPSG%3A3338&bbox=70586,1493385,594874,2017673",
+            "text": "Historical fire perimeters map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=alaska_wildfires%3Aalfresco_relative_flammability_cru_ts40_historical_1900_1999_iem&styles=flammability&format=image%2Fpng&transparent=true&version=1.3&continuousWorld=true&tiled=true&srs=EPSG%3A3338&time=&id=alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem&width=256&height=256&crs=EPSG%3A3338&bbox=594874,1493385,1119162,2017673",
+            "text": "Historical modeled flammability map layer accessible."
+        },
+        {
+            "column": "webapp",
+            "type": "url",
+            "url": "https://gs.mapventure.org/geoserver/wms?service=WMS&request=GetMap&layers=alaska_wildfires%3Aalfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099&styles=flammability&format=image%2Fpng&transparent=true&version=1.3&continuousWorld=true&tiled=true&srs=EPSG%3A3338&time=&id=alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099&width=256&height=256&crs=EPSG%3A3338&bbox=594874,1493385,1119162,2017673",
+            "text": "Projected flammability map layer accessible."
+        },
+    ],
+    "production22222.us-west-2.elasticbeanstalk.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://www.snap.uaf.edu/tools/nwt-climate-explorer",
+            "javascript": "return document.querySelectorAll('#minesites-map canvas').length > 1",
+            "text": "Location map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://www.snap.uaf.edu/tools/nwt-climate-explorer",
+            "javascript": "return document.querySelectorAll('#my-graph .legendlines').length > 1",
+            "text": "Temperature chart populated."
+        },
+    ],
+    "production-dash-cc.us-west-2.elasticbeanstalk.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/community-charts",
+            "javascript": "return document.querySelectorAll('#ccharts g').length > 100",
+            "text": "Average temperature chart populated."
+        },
+        {
+            "column": "webapp",
+            "type": "csv",
+            "url": "https://snap.uaf.edu/tools/community-charts/dash/dlCSV?value=AK124",
+            "text": "Community charts CSV is valid."
+        },
+    ],
+    "permafrost-production.us-west-2.elasticbeanstalk.com": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/permafrost",
+            "javascript": "return document.querySelectorAll('#weather-plot path.point').length > 3",
+            "text": "Permafrost risk chart populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "https://snap.uaf.edu/tools/permafrost",
+            "javascript": "return document.querySelectorAll('#community-table tr').length > 1",
+            "text": "Permafrost risk table populated."
+        },
+    ],
+    "windtool.accap.uaf.edu": [
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "http://windtool.accap.uaf.edu/",
+            "javascript": "return document.querySelectorAll('#map canvas').length > 1",
+            "text": "Location map loaded."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "http://windtool.accap.uaf.edu/",
+            "javascript": "return document.querySelectorAll('#means_box path.box').length > 5",
+            "text": "Monthly wind speed plot populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "http://windtool.accap.uaf.edu/",
+            "javascript": "return document.querySelectorAll('#rose g').length > 100",
+            "text": "Wind speed plot populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "http://windtool.accap.uaf.edu/",
+            "javascript": "return document.querySelectorAll('#rose_monthly g').length > 1000",
+            "text": "Monthly wind speed plot populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "http://windtool.accap.uaf.edu/",
+            "javascript": "return document.querySelectorAll('#threshold_graph g').length > 100",
+            "text": "Modeled wind duration plot populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "http://windtool.accap.uaf.edu/",
+            "javascript": "return document.querySelectorAll('#future_delta_percentiles_graph g').length > 100",
+            "text": "Modeled past and future wind plot populated."
+        },
+        {
+            "column": "webapp",
+            "type": "javascript",
+            "url": "http://windtool.accap.uaf.edu/",
+            "javascript": "return document.querySelectorAll('#future_rose g').length > 500",
+            "text": "Modeled wind speed plot populated."
+        },
     ],
 }
 
@@ -412,6 +599,10 @@ def javascriptTest(check):
     try:
         driver.get(check["url"])
         time.sleep(10)
+        if "click" in check:
+            elementToClick = driver.find_element(By.CSS_SELECTOR, check["click"])
+            elementToClick.click()
+            time.sleep(10) 
         return driver.execute_script(check["javascript"])
     except:
         return False


### PR DESCRIPTION
This PR implements a bunch of custom tests for each of SNAP's web apps, including:

- JavaScript tests that determine if things like maps, charts, and tables are populated with data by selecting corresponding DOM elements, counting them, and testing against sane thresholds
- JSON tests that verify that JSON endpoints are accessible and return valid JSON data
- CSV tests that verify that CSV endpoints are accessible and return valid CSV data

To test, hop on the UAF VPN and view http://snapmonitor.rcs.alaska.edu/xymon to see all these tests in action. Click the icon under the "snap" column to see a listing of each custom test performed for a particular web app.

Also read through the README from this branch to make sure it makes sense.