### PR TITLE
Check if wildfire map is simply loaded because it is not always populated

### DIFF
--- a/snap.py
+++ b/snap.py
@@ -465,8 +465,8 @@ tests = {
             "column": "webapp",
             "type": "javascript",
             "url": "https://snap.uaf.edu/tools/alaska-wildfires",
-            "javascript": "return document.querySelectorAll('#map--leaflet-map path').length > 1 || document.querySelectorAll('.intro').length == 0",
-            "text": "Wildfire map populated or inactive."
+            "javascript": "return document.querySelectorAll('#map--leaflet-map div').length > 10 || document.querySelectorAll('.intro').length == 0",
+            "text": "Wildfire map loaded or inactive."
         },
         {
             "column": "webapp",


### PR DESCRIPTION
This PR modifies one of the tests for the Alaska Wildfire Explorer webapp. Previously we were checking to see if there were active wildfires on the map to confirm that the map is working. This is not a foolproof test, however, because it's possible for everything to be working as intended without any active wildfires on the map, as in the beginning of the fire season in April.

This PR updates the test to check for the existence of div elements inside of the `<div id="map--leaflet-map">` div, which confirms that Leaflet loaded into the div, even if there are no wildfire features on the map.

To test, load the production [Alaska Wildfire Explorer](https://snap.uaf.edu/tools/alaska-wildfires) webapp and copy & paste this into the console to verify that the test passes under normal (working) conditions:

```
document.querySelectorAll('#map--leaflet-map div').length > 10 || document.querySelectorAll('.intro').length == 0
```

The `document.querySelectorAll('.intro').length == 0` part is an alternate check for when the webapp is in inactive mode during the winter, btw.