### PR TITLE
Increase timeout of Arctic EDS temperature table test

### DIFF
--- a/snap.py
+++ b/snap.py
@@ -267,7 +267,7 @@ tests = {
                 })
             """,
             "text": "Temperature table populated ({lat}, {lon}).",
-            "delay": 60
+            "delay": 300
         },
         {
             "column": "webapp",

--- a/snap.py
+++ b/snap.py
@@ -267,7 +267,7 @@ tests = {
                 })
             """,
             "text": "Temperature table populated ({lat}, {lon}).",
-            "delay": 300
+            "delay": 240
         },
         {
             "column": "webapp",


### PR DESCRIPTION
This PR simply increases the timeout for the Arctic EDS temperature table check from 60 seconds to 240 seconds.

To test (indirectly), enter a random but valid lat/lon point on this page:

https://arcticeds.org/climate/temperature/

And observe that it may take 2-3 minutes to finish loading the page. This PR gives Xymon adequate time to finish the test.