### PR TITLE
Increase delay for Garden Helper annual minimums chart check

### DIFF
--- a/snap.py
+++ b/snap.py
@@ -271,7 +271,7 @@ tests = {
                 })
             """,
             "text": "Temperature table populated ({lat}, {lon}).",
-            "delay": 240
+            "delay": 240,
         },
         {
             "column": "webapp",
@@ -452,7 +452,7 @@ tests = {
             "click": ".tab:nth-of-type(2)",
             "javascript": "return document.querySelectorAll('#acharts path').length > 1000",
             "text": "Annual minimums chart populated.",
-            "delay": 60,
+            "delay": 120,
         },
         {
             "column": "webapp",


### PR DESCRIPTION
This PR fixes the intermittent failures of the Garden Helper annual minimums chart check. A Black formatting fix (an extra `,` earlier in the script) is also hitching a ride on this PR. I'm going to self-merge this PR because it is a very straightforward change that is also very hard to test.