### PR TITLE
Add fire API endpoint test for Alaska Wildfire Explorer webapp

### DIFF
--- a/snap.py
+++ b/snap.py
@@ -544,6 +544,14 @@ tests = {
             "url": "https://fire-shim.mapventure.org/viirs.geojson",
             "text": "Hotspots (VIIRS) from fire shim returns valid JSON.",
         },
+        {
+            "column": "webapp",
+            "type": "json",
+            "url": "https://earthmaps.io/fire/point/{lat}/{lon}",
+            "lat_range": [62, 62.5],
+            "lon_range": [-156, -153],
+            "text": "Fire API endpoint JSON is valid ({lat}, {lon}).",
+        },
     ],
     "production22222.us-west-2.elasticbeanstalk.com": [
         {


### PR DESCRIPTION
This PR tests to make sure the following URL returns valid JSON:

https://earthmaps.io/fire/point/{lat}/{lon}

It uses the same range for random lat/lon coordinates that we use for other inland Alaska tests.

This change is already running on our Xymon server and seems to be working fine, so there's not much to test here. Once this is merged, I'll pull this down from the `main` branch on our Xymon server.